### PR TITLE
feat/created setup for deployment of 3 ACN nodes on minikube

### DIFF
--- a/scripts/acn/SETUP.md
+++ b/scripts/acn/SETUP.md
@@ -1,0 +1,17 @@
+## Minikube setup 
+
+At the point of running command `helm install agents-dht-test .` which is in 4a at scripts/acn/README.md, there are some setup needed on minikube to support this project
+
+# 1.Metallb 
+Refer to installation tab on: https://metallb.universe.tf/
+
+After installation of metallb in configuration tab, layer 2 configuration, create a configmap with your minikube subnet
+
+# 2.Instio
+Refer to installation on: https://instio.io/
+
+In documentation tab, click setup then getting started which will show how to download istio in the minikube cluster. In the instioctl command part, notice you need to change the profile from demo to default
+
+3. To resolve error with DNSEndpoint in `helm install agents-dht-test .` change `enable=true` to `enabled=false` in /scripts/acn/helm-chart/values.yaml line 4 gateway and virtual service will be created automatically by helm
+
+4. It is useful to run `minikube ip` to test connectivity and also for metallb configuration to replace the ip subnet with that of minikube

--- a/scripts/acn/helm-chart/templates/acnnode.yaml
+++ b/scripts/acn/helm-chart/templates/acnnode.yaml
@@ -7,6 +7,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: acn-node-{{ .p2pport }}
+  namespace: agents-p2p-dht-testnet
 spec:
   replicas: 1
   selector:
@@ -81,6 +82,7 @@ spec:
     apiVersion: v1 
     metadata:
       name: acn-data
+      namespace: agents-p2p-dht-testnet
     spec:
       accessModes:
       - ReadWriteOnce
@@ -92,6 +94,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: acn-node-{{ .p2pport }}
+  namespace: agents-p2p-dht-testnet
 spec:
   selector:
     app: acn-node-{{ .p2pport }}

--- a/scripts/acn/helm-chart/templates/boostrapistio.yaml
+++ b/scripts/acn/helm-chart/templates/boostrapistio.yaml
@@ -6,6 +6,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: agents-bootstrap-dht-net
+  namespace: agents-p2p-dht-testnet
 spec:
   selector:
     app: {{ $.Values.dns.ingressgw }}
@@ -36,6 +37,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: agents-bootstrap-dht-net
+  namespace: agents-p2p-dht-testnet
 spec:
   gateways:
   - agents-bootstrap-dht-net

--- a/scripts/acn/helm-chart/templates/bootstrapnode.yaml
+++ b/scripts/acn/helm-chart/templates/bootstrapnode.yaml
@@ -7,6 +7,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: acn-node-{{ .p2pport }}
+  namespace: agents-p2p-dht-testnet
 spec:
   replicas: 1
   selector:
@@ -71,6 +72,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: acn-node-{{ .p2pport }}
+  namespace: agents-p2p-dht-testnet
 spec:
   selector:
     app: acn-node-{{ .p2pport }}

--- a/scripts/acn/helm-chart/templates/bootstrapsecret.yaml
+++ b/scripts/acn/helm-chart/templates/bootstrapsecret.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: node-priv-key-{{ .p2pport }}
+  namespace: agents-p2p-dht-testnet
 type: Opaque
 data:
   priv-key: {{ .privkey }}

--- a/scripts/acn/helm-chart/templates/dns.yaml
+++ b/scripts/acn/helm-chart/templates/dns.yaml
@@ -1,18 +1,19 @@
-{{- range $key, $spec := .Values }}
-{{- if eq $key "dns" }}
-{{- if $spec.enabled }}
----
-apiVersion: externaldns.k8s.io/v1alpha1
-kind: DNSEndpoint
-metadata:
-  name: agents-dht-net
-spec:
-  endpoints:
-  - dnsName:  {{ $.Values.dns.dnsname}}
-    recordTTL: 180
-    recordType: CNAME
-    targets:
-    - {{ $.Values.dns.targetgw }}
-{{- end }}
-{{- end }}
-{{- end }}
+# {{- range $key, $spec := .Values }}
+# {{- if eq $key "dns" }}
+# {{- if $spec.enabled }}
+# ---
+# apiVersion: externaldns.k8s.io/v1alpha1
+# kind: DNSEndpoint
+# metadata:
+#   name: agents-dht-net
+#   namespace: agents-p2p-dht-testnet
+# spec:
+#   endpoints:
+#   - dnsName:  {{ $.Values.dns.dnsname}}
+#     recordTTL: 180
+#     recordType: CNAME
+#     targets:
+#     - {{ $.Values.dns.targetgw }}
+# {{- end }}
+# {{- end }}
+# {{- end }}

--- a/scripts/acn/helm-chart/templates/istio.yaml
+++ b/scripts/acn/helm-chart/templates/istio.yaml
@@ -6,6 +6,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: agents-dht-net
+  namespace: agents-p2p-dht-testnet
 spec:
   selector:
     app: {{ $.Values.dns.ingressgw }}
@@ -36,6 +37,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: agents-dht-net
+  namespace: agents-p2p-dht-testnet
 spec:
   gateways:
   - agents-dht-net

--- a/scripts/acn/helm-chart/templates/secret.yaml
+++ b/scripts/acn/helm-chart/templates/secret.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: node-priv-key-{{ .p2pport }}
+  namespace: agents-p2p-dht-testnet
 type: Opaque
 data:
   priv-key: {{ .privkey }}

--- a/scripts/acn/helm-chart/values.yaml
+++ b/scripts/acn/helm-chart/values.yaml
@@ -1,7 +1,7 @@
 # The values here are only for testing. These are not deployed in the production environment
 # DON'T add enything secret here and upload to the git repo
 dns:
-  enabled: true
+  enabled: false
   dnsname: agents-dht-testnet.colearn.fetch-ai.com
   publicdnsname: acn.fetch-ai.com
   ingressgw: istio-agentsig
@@ -9,7 +9,7 @@ dns:
 
 acnnodes:
   enabled: true
-  image: gcr.io/fetch-ai-colearn/acn_node:003d81c00
+  image: gcr.io/fetch-ai-colearn/acn_node:e211d5c42
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
Proposed changes
Setup for deployment of 3 ACN nodes on minikube

Fixes
Minikube setup
At the point of running command helm install agents-dht-test . which is in 4a at scripts/acn/README.md, there are some setup needed on minikube to support this project

1.Metallb
Refer to installation tab on: https://metallb.universe.tf/

After installation of metallb in configuration tab, layer 2 configuration, create a configmap with your minikube subnet

2.Instio
Refer to installation on: https://instio.io/

In documentation tab, click setup then getting started which will show how to download istio in the minikube cluster. In the instioctl command part, notice you need to change the profile from demo to default

To resolve error with DNSEndpoint in helm install agents-dht-test . change enable=true to enabled=false in /scripts/acn/helm-chart/values.yaml line 4 gateway and virtual service will be created automatically by helm

It is useful to run minikube ip to test connectivity and also for metallb configuration to replace the ip subnet with that of minikube

In order to build the local image, run:

./build_upload_img.sh and take note of the image tag.

Replace below IMAGE_TAG_HERE with the image tag.

kubens agents-p2p-dht-testnet
kubectl set image sts/acn-node-9005 acn-node=gcr.io/fetch-ai-colearn/acn_node:{IMAGE_TAG_HERE}
kubectl set image sts/acn-node-9003 acn-node=gcr.io/fetch-ai-colearn/acn_node:{IMAGE_TAG_HERE}
kubectl set image sts/acn-node-9004 acn-node=gcr.io/fetch-ai-colearn/acn_node:{IMAGE_TAG_HERE}

kubens agents-p2p-dht
kubectl set image sts/acn-node-9002 acn-node=gcr.io/fetch-ai-colearn/acn_node:{IMAGE_TAG_HERE}
kubectl set image sts/acn-node-9000 acn-node=gcr.io/fetch-ai-colearn/acn_node:{IMAGE_TAG_HERE}
kubectl set image sts/acn-node-9001 acn-node=gcr.io/fetch-ai-colearn/acn_node:{IMAGE_TAG_HERE}


To deploy a test network do the following steps:

1. update the image tag (two instances) in the `helm-chart/values.yaml`
2. `cd helm-chart`

**NOTE: Make sure to be in the `agents-p2p-dht-testnet` namespace before proceeding**

3. a) If this is the first time deploying run `helm install agents-dht-test .`
   b) If you are upgrading an existing installation (see if there is one by `helm ls`) run `helm upgrade agents-dht-test .`